### PR TITLE
Fix maven warning about missing version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -91,3 +92,4 @@
         </dependency>
     </dependencies>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
Solves this warning:

```
[WARNING]                                                                                                                                                                                                         
[WARNING] Some problems were encountered while building the effective model for mircokroon.minecraft-world-downloader:minecraft-world-downloader:jar:1.0                                                          
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 17, column 21                                                                                      
[WARNING]                                                                                                                                                                                                         
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.                                                                                                       
[WARNING]                                                                                                                                                                                                         
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.                                                                                                        
[WARNING]
```

https://stackoverflow.com/a/6804278/6287070