### PR TITLE
Optionally stop world generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ tmp/
 *.iml
 
 cache/
+
+*.dat
+
+*.mca

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then connect to ```localhost``` in Minecraft to start downloading the world. The
 |  --minecraft | %appdata%/.minecraft | Path to your Minecraft installation, used for Mojang authentication |
 | --render-distance | 75 | Render distance of (in chunks) of the overview map |
 |  --seed | 0 | World seed, useful when generating chunks after downloading |
+|  --enable-world-gen | true | When set to false, will prevent new terrain from being generated in-game. |
 
 ### Running on Linux
 To easily download the latest release using the terminal, the following commands can be used:

--- a/src/main/java/Launcher.java
+++ b/src/main/java/Launcher.java
@@ -70,6 +70,10 @@ public class Launcher {
             .setDefault(true)
             .type(boolean.class)
             .help("Set to false to disable writing the chunks, mostly for debugging purposes.");
+        parser.addArgument("-w", "--enable-world-gen").dest("enable-world-gen")
+            .setDefault(true)
+            .type(boolean.class)
+            .help("When false, set world type to a superflat void to prevent new chunks from being added.");
 
         Namespace ns = null;
         try {

--- a/src/main/java/game/Game.java
+++ b/src/main/java/game/Game.java
@@ -50,6 +50,7 @@ public abstract class Game {
     private static DataReader clientBoundDataReader;
     private static EncryptionManager encryptionManager;
     private static CompressionManager compressionManager;
+    private static boolean enableWorldGen;
 
     public static int getDataVersion() {
         return dataVersion;
@@ -103,6 +104,7 @@ public abstract class Game {
         if (args.getBoolean("gui")) {
             GuiManager.showGui();
         }
+        enableWorldGen = args.getBoolean("enable-world-gen");
 
         versionHandler = VersionHandler.createVersionHandler();
     }
@@ -232,4 +234,7 @@ public abstract class Game {
         return args.getInt("render-distance");
     }
 
+    public static boolean isWorldGenEnabled() {
+        return enableWorldGen;
+    }
 }

--- a/src/main/java/game/data/WorldManager.java
+++ b/src/main/java/game/data/WorldManager.java
@@ -184,12 +184,26 @@ public class WorldManager extends Thread {
             data.add("Version", versionTag);
         }
 
+        if (!Game.isWorldGenEnabled()) {
+            disableWorldGeneration(data);
+        }
+
         // write the file
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         root.write(new DataOutputStream(output));
 
         byte[] compressed = CompressionManager.gzipCompress(output.toByteArray());
         Files.write(levelDat.toPath(), compressed);
+    }
+
+    /**
+     * Set world type to a superflat void world.
+     */
+    private static void disableWorldGeneration(CompoundTag data) {
+        data.add("generatorName", new StringTag("flat"));
+
+        // this is the 1.12.2 superflat format, but it still works in later versions.
+        data.add("generatorOptions", new StringTag("3;minecraft:air;127"));
     }
 
     /**


### PR DESCRIPTION
- Added optional -w commandline option, when set to false it will be set the world generator of the output world to a superflat void so that no new chunks are created.

Closes #33 