### PR TITLE
Fix linux home path

### DIFF
--- a/src/main/java/Launcher.java
+++ b/src/main/java/Launcher.java
@@ -93,7 +93,7 @@ public class Launcher {
         if (SystemUtils.IS_OS_WINDOWS) {
             return Paths.get("%appdata%", ".minecraft").toString();
         } else if (SystemUtils.IS_OS_LINUX) {
-            return System.getProperty("user.home") + "/.minecraft";
+            return Paths.get(System.getProperty("user.home"), ".minecraft").toString();
         } else {
             return ".minecraft";
         }

--- a/src/main/java/Launcher.java
+++ b/src/main/java/Launcher.java
@@ -93,7 +93,7 @@ public class Launcher {
         if (SystemUtils.IS_OS_WINDOWS) {
             return Paths.get("%appdata%", ".minecraft").toString();
         } else if (SystemUtils.IS_OS_LINUX) {
-            return Paths.get("~", ".minecraft").toString();
+            return System.getProperty("user.home") + "/.minecraft";
         } else {
             return ".minecraft";
         }


### PR DESCRIPTION
I think the tilde ``~`` expansion is not supported by java.
```
java.nio.file.NoSuchFileException: ~/.minecraft/launcher_profiles.json
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:370)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:421)
        at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
        at java.base/java.nio.file.Files.newInputStream(Files.java:155)
        at java.base/java.nio.file.Files.newBufferedReader(Files.java:2838)
        at java.base/java.nio.file.Files.readAllLines(Files.java:3329)
        at java.base/java.nio.file.Files.readAllLines(Files.java:3369)
        at proxy.auth.ClientAuthenticator.getFile(ClientAuthenticator.java:47)
        at proxy.auth.ClientAuthenticator.<init>(ClientAuthenticator.java:28)
        at proxy.EncryptionManager.lambda$sendReplacementEncryptionConfirmation$7(EncryptionManager.java:250)
        at proxy.EncryptionManager.disconnectOnError(EncryptionManager.java:93)
        at proxy.EncryptionManager.sendReplacementEncryptionConfirmation(EncryptionManager.java:250)
        at proxy.EncryptionManager.lambda$setClientEncryptionConfirmation$6(EncryptionManager.java:238)
        at proxy.EncryptionManager.attempt(EncryptionManager.java:80)
        at proxy.EncryptionManager.setClientEncryptionConfirmation(EncryptionManager.java:227)
        at packets.builder.ServerBoundLoginPacketBuilder.lambda$new$1(ServerBoundLoginPacketBuilder.java:28)
        at packets.builder.PacketBuilder.build(PacketBuilder.java:46)
        at packets.DataReader.readPackets(DataReader.java:161)
        at packets.DataReader.pushData(DataReader.java:116)
        at proxy.ProxyServer.lambda$run$4(ProxyServer.java:93)
        at proxy.ProxyServer.attempt(ProxyServer.java:138)
        at proxy.ProxyServer.lambda$run$6(ProxyServer.java:90)
        at java.base/java.lang.Thread.run(Thread.java:834)
Cannot read or find '~/.minecraft/launcher_profiles.json'!
Use launch option: "-m /path/to/.minecraft/" to indicate the location of your Minecraft installation.
chiller@debian:~/Desktop/git/minecraft-world-downloader$ ls ~/.minecraft/launcher_profiles.json
/home/chiller/.minecraft/launcher_profiles.json
```

I guess the reason why ``-m ~/.minecraft`` fixes it is because the shell expands it to the absolute path before it gets passed to the world downloader.

I tested ``System.getProperty("user.home")`` on debian 10 and it worked fine and created ``/home/chiller``