### PR TITLE
Added OSX to getDefaultPath()

### DIFF
--- a/src/main/java/Launcher.java
+++ b/src/main/java/Launcher.java
@@ -94,6 +94,8 @@ public class Launcher {
             return Paths.get("%appdata%", ".minecraft").toString();
         } else if (SystemUtils.IS_OS_LINUX) {
             return Paths.get(System.getProperty("user.home"), ".minecraft").toString();
+        } else if (SystemUtils.IS_OS_UNIX) {
+            return Paths.get("/Users/", System.getProperty("user.name"), "/Library/Application Support/minecraft").toString();
         } else {
             return ".minecraft";
         }


### PR DESCRIPTION
The default path for macOS is `/Users/christopher/Library/Application Support/minecraft` replacing christopher with the name of the user account.