### PR TITLE
Change the command used for process detection on macOS

### DIFF
--- a/src/main/java/proxy/auth/AuthDetailsFromProcess.java
+++ b/src/main/java/proxy/auth/AuthDetailsFromProcess.java
@@ -71,9 +71,6 @@ public class AuthDetailsFromProcess {
                     .map(this::getLaunchParametersWindows)
                     .filter(line -> line.contains("--accessToken"))
                     .collect(Collectors.toList());
-        } else if (SystemUtils.IS_OS_MAC_OSX) {
-            return findCandidateProcessMacOS().stream()
-            .map(a -> "" + a).collect(Collectors.toList());
         } else {
             return findCandidateProcessUnix().stream()
                     .map(a -> "" + a).collect(Collectors.toList());
@@ -103,33 +100,17 @@ public class AuthDetailsFromProcess {
     }
 
     /**
-     * For unix (non-macOS) systems we can use one command to get all java processes and their arguments. The first line will be a
+     * For unix systems we can use one command to get all java processes and their arguments. The first line will be a
      * header that we can read out to get the required index for the arguments.
      */
     private List<String> findCandidateProcessUnix() throws IOException {
-        Process p = Runtime.getRuntime().exec("ps -fC java");
-
-        BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-        List<String> res = new ArrayList<>();
-
-        String line;
-        while ((line = input.readLine()) != null) {
-            if (line.contains("java") && line.contains("--accessToken")) {
-                res.add(line);
-            }
+        Process p;
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            p = Runtime.getRuntime().exec("ps ax");
         }
-        input.close();
-
-        return res;
-    }
-
-    /**
-     * macOS systems have a different version of ps installed which requires different arguments,
-     * but we can just get the entire process list and filter through it.
-     */
-    private List<String> findCandidateProcessMacOS() throws IOException {
-        Process p = Runtime.getRuntime().exec("ps ax");
+        else {
+            p = Runtime.getRuntime().exec("ps -fC java");
+        }
 
         BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
 

--- a/src/main/java/proxy/auth/AuthDetailsFromProcess.java
+++ b/src/main/java/proxy/auth/AuthDetailsFromProcess.java
@@ -71,6 +71,9 @@ public class AuthDetailsFromProcess {
                     .map(this::getLaunchParametersWindows)
                     .filter(line -> line.contains("--accessToken"))
                     .collect(Collectors.toList());
+        } else if (SystemUtils.IS_OS_MAC_OSX) {
+            return findCandidateProcessMacOS().stream()
+            .map(a -> "" + a).collect(Collectors.toList());
         } else {
             return findCandidateProcessUnix().stream()
                     .map(a -> "" + a).collect(Collectors.toList());
@@ -100,11 +103,33 @@ public class AuthDetailsFromProcess {
     }
 
     /**
-     * For unix systems we can use one command to get all java processes and their arguments. The first line will be a
+     * For unix (non-macOS) systems we can use one command to get all java processes and their arguments. The first line will be a
      * header that we can read out to get the required index for the arguments.
      */
     private List<String> findCandidateProcessUnix() throws IOException {
         Process p = Runtime.getRuntime().exec("ps -fC java");
+
+        BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+        List<String> res = new ArrayList<>();
+
+        String line;
+        while ((line = input.readLine()) != null) {
+            if (line.contains("java") && line.contains("--accessToken")) {
+                res.add(line);
+            }
+        }
+        input.close();
+
+        return res;
+    }
+
+    /**
+     * macOS systems have a different version of ps installed which requires different arguments,
+     * but we can just get the entire process list and filter through it.
+     */
+    private List<String> findCandidateProcessMacOS() throws IOException {
+        Process p = Runtime.getRuntime().exec("ps ax");
 
         BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
 


### PR DESCRIPTION
Fixes #189 

At first I was hesitant about making this change as any process named java that had "--accesstoken" argument would get detected as minecraft, but then I realised the unix detection already does this so I decided it's fine.

I could not find any kind of contributing file, so I just tried to match the code's style as much as possible, I hope it's ok.

This tool still isn't perfect on macOS unfortunately due to issue #201, but apart from font rendering I haven't seen any issue.