### PR TITLE
Fixed crash from java version ending with -ea

### DIFF
--- a/src/main/java/game/data/registries/RegistryLoader.java
+++ b/src/main/java/game/data/registries/RegistryLoader.java
@@ -48,6 +48,7 @@ public class RegistryLoader {
     public static RegistryLoader forVersion(String version) {
         return knownLoaders.computeIfAbsent(version, (v) -> {
             try {
+
                 return new RegistryLoader(v);
             } catch (IOException|InterruptedException e) {
                 e.printStackTrace();
@@ -99,6 +100,9 @@ public class RegistryLoader {
                 version = version.substring(0, dot);
             }
         }
+
+        if (version.endsWith("-ea"))
+            version= version.split("-")[0];
         return Integer.parseInt(version);
     }
 


### PR DESCRIPTION
Kept getting the following exception when attempting to download world
Exception in thread "Chunk Parser Service" java.lang.NumberFormatException: For input string: "17-ea"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
        at java.base/java.lang.Integer.parseInt(Integer.java:668)
        at java.base/java.lang.Integer.parseInt(Integer.java:786)
        at game.data.registries.RegistryLoader.getJavaVersion(RegistryLoader.java:102)
        at game.data.registries.RegistryLoader.getReportsFromServerJar(RegistryLoader.java:121)
        at game.data.registries.RegistryLoader.<init>(RegistryLoader.java:72)
        at game.data.registries.RegistryLoader.lambda$forVersion$0(RegistryLoader.java:51)
        at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
        at game.data.registries.RegistryLoader.forVersion(RegistryLoader.java:49)
        at game.data.chunk.palette.GlobalPaletteProvider.requestPalette(GlobalPaletteProvider.java:46)
        at game.data.chunk.palette.GlobalPaletteProvider.getGlobalPalette(GlobalPaletteProvider.java:28)
        at game.data.chunk.palette.GlobalPaletteProvider.getGlobalPalette(GlobalPaletteProvider.java:35)
        at game.data.chunk.palette.Palette.<init>(Palette.java:32)
        at game.data.chunk.palette.Palette.empty(Palette.java:48)
        at game.data.chunk.Chunk.updateBlock(Chunk.java:483)
        at game.data.chunk.version.Chunk_1_16.updateBlocks(Chunk_1_16.java:71)
        at game.data.WorldManager.lambda$multiBlockChange$6(WorldManager.java:684)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:831)

Turns out my crash was due to `System.getProperty("java.version")` returning a versing ending with -ea causing parseInt to raise an exception. 
