### PR TITLE
Update Protocol to include 1.19.1

### DIFF
--- a/src/main/resources/protocol-versions.json
+++ b/src/main/resources/protocol-versions.json
@@ -278,6 +278,44 @@
 				"0x30": "UseItemOn",
 				"0x31": "UseItem"
 			}
+		},
+		"760": {
+			"version": "1.19.1",
+			"dataVersion": 3117,
+			"clientBound": {
+				"0x00": "AddEntity",
+				"0x02": "AddPlayer",
+				"0x07": "BlockEntityData",
+				"0x09": "BlockUpdate",
+				"0x10": "ContainerClose",
+				"0x11": "ContainerSetContent",
+				"0x1c": "ForgetLevelChunk",
+				"0x21": "LevelChunkWithLight",
+				"0x24": "LightUpdate",
+				"0x25": "Login",
+				"0x26": "MapItemData",
+				"0x28": "MoveEntityPos",
+				"0x29": "MoveEntityPosRot",
+				"0x2d": "OpenScreen",
+				"0x3b": "RemoveEntities",
+				"0x3e": "Respawn",
+				"0x40": "SectionBlocksUpdate",
+				"0x50": "SetEntityData",
+				"0x53": "SetEquipment",
+				"0x62": "SystemChat",
+				"0x66": "TeleportEntity"
+			},
+			"serverBound": {
+				"0x0c": "ContainerClose",
+				"0x10": "Interact",
+				"0x14": "MovePlayerPos",
+				"0x15": "MovePlayerPosRot",
+				"0x16": "MovePlayerRot",
+				"0x18": "MoveVehicle",
+				"0x29": "SetCommandBlock",
+				"0x31": "UseItemOn",
+				"0x32": "UseItem"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Updates the protocols and adds 1.19.1 for 1.19.1 compatibility. Functionality seems to work, but is untested.

Used Sources:
https://github.com/dmulloy2/ProtocolLib/blob/master/src/main/java/com/comphenix/protocol/PacketType.java