### PR TITLE
Add new packet IDs for protocol 760 (1.19.1/2), and improve JRE check logic.

### DIFF
--- a/src/main/java/game/data/registries/RegistryLoader.java
+++ b/src/main/java/game/data/registries/RegistryLoader.java
@@ -115,13 +115,19 @@ public class RegistryLoader {
         String serverUrl = VersionManifestHandler.findServerUrl(version);
 
         /*
-         * Since newer Minecraft versions use Java 1.16, we can't generate reports if the user is still using an older
-         * version of Java. To maintain support for older Java versions, this check is only done at this stage.
+         * Since newer Minecraft versions use Java 17 (1.18+) or Java 16 (1.17.x), we can't generate reports if the user is using
+         * an incompatible version of Java. To maintain support for older Java versions, this check is only done at this stage.
          */
-        if (Config.versionReporter().isAtLeast1_17() && getJavaVersion() < 16) {
-            System.err.println("Cannot run Minecraft version 1.17+ with a Java version below 16. You are currently using Java version " + getJavaVersion() + ".");
+        if (Config.versionReporter().isAtLeast1_18() && getJavaVersion() < 17) {
+            System.err.println("Cannot run Minecraft version 1.18+ with a Java version below 17. You are currently using Java version " + getJavaVersion() + ".");
+            System.err.println("Please consider upgrading your Java version to at least version 17.\n");
+            System.err.println("If you have already installed a compatible version of Java and are still seeing this message, please ensure that your JAVA_HOME environment variable is set correctly.\n");
+            throw new UnsupportedMinecraftVersionException("Minecraft version 1.18+ is not supported for Java version " + getJavaVersion());
+        } else if (Config.versionReporter().isAtLeast1_17() && getJavaVersion() < 16) {
+            System.err.println("Cannot run Minecraft version 1.17.x with a Java version below 16. You are currently using Java version " + getJavaVersion() + ".");
             System.err.println("Please consider upgrading your Java version to at least version 16.\n");
-            throw new UnsupportedMinecraftVersionException("Minecraft version 1.17 is not supported for java version " + getJavaVersion());
+            System.err.println("If you have already installed a compatible version of Java and are still seeing this message, please ensure that your JAVA_HOME environment variable is set correctly.\n");
+            throw new UnsupportedMinecraftVersionException("Minecraft version 1.17.x is not supported for Java version " + getJavaVersion());
         }
 
         downloadServerJar(serverUrl);

--- a/src/main/resources/protocol-versions.json
+++ b/src/main/resources/protocol-versions.json
@@ -281,7 +281,7 @@
 		},
 		"760": {
 			"version": "1.19.1",
-			"dataVersion": 3105,
+			"dataVersion": 3117,
 			"clientBound": {
 				"0x00": "AddEntity",
 				"0x02": "AddPlayer",

--- a/src/main/resources/protocol-versions.json
+++ b/src/main/resources/protocol-versions.json
@@ -278,6 +278,44 @@
 				"0x30": "UseItemOn",
 				"0x31": "UseItem"
 			}
-		}
+		},
+		"760": {
+			"version": "1.19.1",
+			"dataVersion": 3105,
+			"clientBound": {
+				"0x00": "AddEntity",
+				"0x02": "AddPlayer",
+				"0x07": "BlockEntityData",
+				"0x09": "BlockUpdate",
+				"0x10": "ContainerClose",
+				"0x11": "ContainerSetContent",
+				"0x1c": "ForgetLevelChunk",
+				"0x21": "LevelChunkWithLight",
+				"0x24": "LightUpdate",
+				"0x25": "Login",
+				"0x26": "MapItemData",
+				"0x28": "MoveEntityPos",
+				"0x29": "MoveEntityPosRot",
+				"0x2d": "OpenScreen",
+				"0x3b": "RemoveEntities",
+				"0x3e": "Respawn",
+				"0x40": "SectionBlocksUpdate",
+				"0x50": "SetEntityData",
+				"0x53": "SetEquipment",
+				"0x62": "SystemChat",
+				"0x66": "TeleportEntity"
+			},
+			"serverBound": {
+				"0x0c": "ContainerClose",
+				"0x10": "Interact",
+				"0x14": "MovePlayerPos",
+				"0x15": "MovePlayerPosRot",
+				"0x16": "MovePlayerRot",
+				"0x18": "MoveVehicle",
+				"0x29": "SetCommandBlock",
+				"0x31": "UseItemOn",
+				"0x32": "UseItem"
+			}
+		}	
 	}
 }

--- a/src/test/java/game/protocol/ProtocolVersionHandlerTest.java
+++ b/src/test/java/game/protocol/ProtocolVersionHandlerTest.java
@@ -24,6 +24,7 @@ class ProtocolVersionHandlerTest {
         versions.put(757, "1.18");
         versions.put(758, "1.18");
         versions.put(759, "1.19");
+        versions.put(760, "1.19.1");
 
         versions.forEach((k, v) -> {
             assertThat(pvh.getProtocolByProtocolVersion(k).getVersion()).isEqualTo(v);


### PR DESCRIPTION
This PR adds new packet IDs for protocol 760 (1.19.1/2), as well as improves the JRE check to reflect the fact that 1.18+ uses Java 17, and 1.17.x uses Java 16.

I've also added an additional message to the JRE check regarding `JAVA_HOME` that may help users debug their setups.

## Notes
* ~~`dataVersion` is _intentionally_ set to 3105 (1.19) instead of 3117 (1.19.1). This is because the actual chunk/region data that is written to disk still uses a `DataVersion` value of 3105 (1.19), so it wouldn't really make sense to set the `DataVersion` value in `level.dat` to 3117 as a result. This behaviour is also consistent with how minecraft-world-downloader handles chunk data versions for other Minecraft versions too, such as 1.18.2, 1.17.1, or even 1.16.5.~~
	* ~~This is pretty much the main change that is different from SesuMoe's PR #424, aside from the additional changes made in this PR.~~
	* This change was ultimately reverted as it caused issues with `getProtocolByDataVersion()` — joining a 1.19 (759) server with all MVN report caches cleared will result in _both_ the 1.19 and 1.19.1 reports being generated, which is undesirable behaviour.
* Following the above point, it /seems/ that there haven't been any actual changes made to the chunk data format since 3105 (1.19) anyway — or at least, none that require any accomodation in minecraft-world-downloader's codebase. As a result…
	* No changes were made to `Version`, `VersionReporter`, or `ChunkFactory`.
	* No `Chunk_1_19_1` or `ChunkSection_1_19_1` classes were created.
* A `ClientBoundGamePacketHandler_1_19_1` class was not created, as the changes made in protocol 760 do not seem to necessitate one.
* The packet IDs were taken from ProtocolLib's existing RE work found in `PacketType.Play.Server` (for `clientBound`) and `PacketType.Play.Client` (for `serverBound`).