### PR TITLE
Add new packet IDs for protocol 761 (1.19.3)

### DIFF
--- a/src/main/java/config/Version.java
+++ b/src/main/java/config/Version.java
@@ -10,6 +10,7 @@ public enum Version {
     V1_17(755, 2724),
     V1_18(757, 2860),
     V1_19(759, 3105),
+    V1_19_3(761, 3218),
     ANY(0, 0);
 
     public final int dataVersion;
@@ -30,23 +31,23 @@ public enum Version {
             case V1_17 -> versionReporter.isAtLeast1_17();
             case V1_18 -> versionReporter.isAtLeast1_18();
             case V1_19 -> versionReporter.isAtLeast1_19();
+            case V1_19_3 -> versionReporter.isAtLeast1_19_3();
             case ANY -> true;
-            default -> false;
         };
     }
 
     public boolean isDataVersion(int dataVersion) {
-        switch (this) {
-            case V1_12: return VersionReporter.isAtLeast1_12(dataVersion);
-            case V1_13: return VersionReporter.isAtLeast1_13(dataVersion);
-            case V1_14: return VersionReporter.isAtLeast1_14(dataVersion);
-            case V1_15: return VersionReporter.isAtLeast1_15(dataVersion);
-            case V1_16: return VersionReporter.isAtLeast1_16(dataVersion);
-            case V1_17: return VersionReporter.isAtLeast1_17(dataVersion);
-            case V1_18: return VersionReporter.isAtLeast1_18(dataVersion);
-            case V1_19: return VersionReporter.isAtLeast1_19(dataVersion);
-            case ANY: return true;
-            default: return false;
-        }
+        return switch (this) {
+            case V1_12 -> VersionReporter.isAtLeast1_12(dataVersion);
+            case V1_13 -> VersionReporter.isAtLeast1_13(dataVersion);
+            case V1_14 -> VersionReporter.isAtLeast1_14(dataVersion);
+            case V1_15 -> VersionReporter.isAtLeast1_15(dataVersion);
+            case V1_16 -> VersionReporter.isAtLeast1_16(dataVersion);
+            case V1_17 -> VersionReporter.isAtLeast1_17(dataVersion);
+            case V1_18 -> VersionReporter.isAtLeast1_18(dataVersion);
+            case V1_19 -> VersionReporter.isAtLeast1_19(dataVersion);
+            case V1_19_3 -> VersionReporter.isAtLeast1_19_3(dataVersion);
+            case ANY -> true;
+        };
     }
 }

--- a/src/main/java/config/VersionReporter.java
+++ b/src/main/java/config/VersionReporter.java
@@ -59,6 +59,7 @@ public class VersionReporter {
     }
     public boolean isAtLeast1_18() { return protocolVersion >= Version.V1_18.protocolVersion; }
     public boolean isAtLeast1_19() { return protocolVersion >= Version.V1_19.protocolVersion; }
+    public boolean isAtLeast1_19_3() { return protocolVersion >= Version.V1_19_3.protocolVersion; }
 
     public static boolean isAtLeast1_12(int dataVersion) {
         return dataVersion >= Version.V1_12.dataVersion;
@@ -83,5 +84,8 @@ public class VersionReporter {
     }
     public static boolean isAtLeast1_19(int dataVersion) {
         return dataVersion >= Version.V1_19.dataVersion;
+    }
+    public static boolean isAtLeast1_19_3(int dataVersion) {
+        return dataVersion >= Version.V1_19_3.dataVersion;
     }
 }

--- a/src/main/java/game/data/chunk/ChunkFactory.java
+++ b/src/main/java/game/data/chunk/ChunkFactory.java
@@ -30,7 +30,7 @@ public class ChunkFactory {
     public void clear() {
         this.unparsedChunks = new ConcurrentHashMap<>();
 
-        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "Chunk Parser Service"));;
+        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "Chunk Parser Service"));
     }
 
     /**
@@ -141,6 +141,7 @@ public class ChunkFactory {
      */
     private static Chunk getVersionedChunk(CoordinateDim2D chunkPos) {
         return Config.versionReporter().select(Chunk.class,
+                Option.of(Version.V1_19_3, () -> new Chunk_1_19_3(chunkPos)),
                 Option.of(Version.V1_19, () -> new Chunk_1_19(chunkPos)),
                 Option.of(Version.V1_18, () -> new Chunk_1_18(chunkPos)),
                 Option.of(Version.V1_17, () -> new Chunk_1_17(chunkPos)),
@@ -159,6 +160,7 @@ public class ChunkFactory {
      */
     private static Chunk getVersionedChunk(int dataVersion, CoordinateDim2D chunkPos) {
         return VersionReporter.select(dataVersion, Chunk.class,
+                Option.of(Version.V1_19_3, () -> new Chunk_1_19_3(chunkPos)),
                 Option.of(Version.V1_19, () -> new Chunk_1_19(chunkPos)),
                 Option.of(Version.V1_18, () -> new Chunk_1_18(chunkPos)),
                 Option.of(Version.V1_17, () -> new Chunk_1_17(chunkPos)),

--- a/src/main/java/game/data/chunk/version/ChunkSection_1_19_3.java
+++ b/src/main/java/game/data/chunk/version/ChunkSection_1_19_3.java
@@ -1,0 +1,23 @@
+package game.data.chunk.version;
+
+import config.Version;
+import game.data.chunk.Chunk;
+import game.data.chunk.palette.Palette;
+import se.llbit.nbt.Tag;
+
+public class ChunkSection_1_19_3 extends ChunkSection_1_19 {
+    public static final Version VERSION = Version.V1_19_3;
+
+    @Override
+    public int getDataVersion() {
+        return VERSION.dataVersion;
+    }
+
+    public ChunkSection_1_19_3(byte y, Palette palette, Chunk chunk) {
+        super(y, palette, chunk);
+    }
+
+    public ChunkSection_1_19_3(int sectionY, Tag nbt) {
+        super(sectionY, nbt);
+    }
+}

--- a/src/main/java/game/data/chunk/version/Chunk_1_19_3.java
+++ b/src/main/java/game/data/chunk/version/Chunk_1_19_3.java
@@ -1,0 +1,28 @@
+package game.data.chunk.version;
+
+import config.Version;
+import game.data.chunk.ChunkSection;
+import game.data.chunk.palette.Palette;
+import game.data.coordinates.CoordinateDim2D;
+import se.llbit.nbt.SpecificTag;
+
+public class Chunk_1_19_3 extends Chunk_1_19 {
+    public static final Version VERSION = Version.V1_19_3;
+
+    @Override
+    public int getDataVersion() { return VERSION.dataVersion; }
+
+    public Chunk_1_19_3(CoordinateDim2D location) {
+        super(location);
+    }
+
+    @Override
+    public ChunkSection createNewChunkSection(byte y, Palette palette) {
+        return new ChunkSection_1_19_3(y, palette, this);
+    }
+
+    @Override
+    protected ChunkSection parseSection(int sectionY, SpecificTag section) {
+        return new ChunkSection_1_19_3(sectionY, section);
+    }
+}

--- a/src/main/resources/protocol-versions.json
+++ b/src/main/resources/protocol-versions.json
@@ -316,6 +316,44 @@
 				"0x31": "UseItemOn",
 				"0x32": "UseItem"
 			}
-		}	
+		},
+		"761": {
+			"version": "1.19.3",
+			"dataVersion": "3218",
+			"clientBound": {
+				"0x00": "AddEntity",
+				"0x02": "AddPlayer",
+				"0x07": "BlockEntityData",
+				"0x09": "BlockUpdate",
+				"0x0f": "ContainerClose",
+				"0x10": "ContainerSetContent",
+				"0x1b": "ForgetLevelChunk",
+				"0x20": "LevelChunkWithLight",
+				"0x23": "LightUpdate",
+				"0x24": "Login",
+				"0x25": "MapItemData",
+				"0x27": "MoveEntityPos",
+				"0x28": "MoveEntityPosRot",
+				"0x2c": "OpenScreen",
+				"0x3a": "RemoveEntities",
+				"0x3d": "Respawn",
+				"0x3f": "SectionBlocksUpdate",
+				"0x4e": "SetEntityData",
+				"0x51": "SetEquipment",
+				"0x60": "SystemChat",
+				"0x64": "TeleportEntity"
+			},
+			"serverBound": {
+				"0x0b": "ContainerClose",
+				"0x0f": "Interact",
+				"0x13": "MovePlayerPos",
+				"0x14": "MovePlayerPosRot",
+				"0x15": "MovePlayerRot",
+				"0x17": "MoveVehicle",
+				"0x29": "SetCommandBlock",
+				"0x31": "UseItemOn",
+				"0x32": "UseItem"
+			}
+		}
 	}
 }


### PR DESCRIPTION
As in previous version update PR, the packet IDs were taken from ProtocolLib.
Seems like nothing except packet IDs was changed in 1.19.3 as I was able to dump chunks from my server on that version.