### PR TITLE
Fix entity metadata not being parsed correctly

### DIFF
--- a/src/main/java/game/data/entity/metadata/MetaData.java
+++ b/src/main/java/game/data/entity/metadata/MetaData.java
@@ -40,6 +40,7 @@ public abstract class MetaData {
      */
     public static MetaData getVersionedMetaData() {
         return Config.versionReporter().select(MetaData.class,
+                Option.of(Version.V1_19_3, MetaData_1_19_3::new),
                 Option.of(Version.V1_13, MetaData_1_13::new),
                 Option.of(Version.ANY, MetaData_1_12::new)
         );

--- a/src/main/java/game/data/entity/metadata/MetaData_1_19_3.java
+++ b/src/main/java/game/data/entity/metadata/MetaData_1_19_3.java
@@ -1,0 +1,53 @@
+package game.data.entity.metadata;
+
+import config.Config;
+import packets.DataTypeProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class MetaData_1_19_3 extends MetaData_1_13{
+
+    private static Map<Integer, Consumer<DataTypeProvider>> typeHandlers;
+    static {
+        typeHandlers = new HashMap<>();
+        typeHandlers.put(0, DataTypeProvider::readNext);
+        typeHandlers.put(1, DataTypeProvider::readVarInt);
+        typeHandlers.put(2, DataTypeProvider::readVarLong);
+        typeHandlers.put(3, DataTypeProvider::readFloat);
+        typeHandlers.put(4, DataTypeProvider::readString);
+        typeHandlers.put(5, DataTypeProvider::readChat);
+        typeHandlers.put(6, DataTypeProvider::readOptChat);
+        typeHandlers.put(7, DataTypeProvider::readSlot);
+        typeHandlers.put(8, DataTypeProvider::readBoolean);
+        typeHandlers.put(9, DataTypeProvider::readBoolean);
+        typeHandlers.put(10, DataTypeProvider::readLong);
+        typeHandlers.put(11, provider -> {
+            if (provider.readBoolean()) {
+                provider.readLong();
+            }
+        });
+        typeHandlers.put(12, DataTypeProvider::readVarInt);
+        typeHandlers.put(14, DataTypeProvider::readVarInt);
+        typeHandlers.put(15, DataTypeProvider::readNbtTag);
+        typeHandlers.put(17, (provider -> {
+            provider.readVarInt();
+            provider.readVarInt();
+            provider.readVarInt();
+        }));
+        typeHandlers.put(18, DataTypeProvider::readOptVarInt);
+        typeHandlers.put(19, DataTypeProvider::readVarInt);
+    }
+
+    @Override
+    public Consumer<DataTypeProvider> getTypeHandler(int i) {
+
+        if (Config.versionReporter().isAtLeast1_19_3())
+        {
+            return typeHandlers.getOrDefault(i, null);
+        }
+
+        return super.getTypeHandler(i);
+    }
+}

--- a/src/main/java/game/data/entity/specific/ArmorStand.java
+++ b/src/main/java/game/data/entity/specific/ArmorStand.java
@@ -1,7 +1,7 @@
 package game.data.entity.specific;
 
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import se.llbit.nbt.*;
 
@@ -42,7 +42,7 @@ public class ArmorStand extends MobEntity {
     }
 }
 
-class ArmorStandMetaData extends MetaData_1_13 {
+class ArmorStandMetaData extends MetaData_1_19_3 {
     private boolean isSmall;
     private boolean hasArms = true;
     private boolean hasNoBasePlate;

--- a/src/main/java/game/data/entity/specific/Axolotl.java
+++ b/src/main/java/game/data/entity/specific/Axolotl.java
@@ -3,7 +3,7 @@ package game.data.entity.specific;
 import java.util.function.Consumer;
 
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import se.llbit.nbt.ByteTag;
 import se.llbit.nbt.CompoundTag;
@@ -39,7 +39,7 @@ public class Axolotl extends MobEntity {
         }
     }
 
-    private class AxolotlMetaData extends MetaData_1_13 {
+    private class AxolotlMetaData extends MetaData_1_19_3 {
 
         int variant = 0;
         boolean wasSpawnedFromBucket = false;

--- a/src/main/java/game/data/entity/specific/Cat.java
+++ b/src/main/java/game/data/entity/specific/Cat.java
@@ -3,7 +3,7 @@ package game.data.entity.specific;
 import java.util.function.Consumer;
 
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import packets.UUID;
 import se.llbit.nbt.ByteTag;
@@ -41,7 +41,7 @@ public class Cat extends MobEntity {
         }
     }
 
-    private class CatMetaData extends MetaData_1_13 {
+    private class CatMetaData extends MetaData_1_19_3 {
 
         int type = 1;
         int collarColor = 14;

--- a/src/main/java/game/data/entity/specific/DroppedItem.java
+++ b/src/main/java/game/data/entity/specific/DroppedItem.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import game.data.container.Slot;
 import game.data.entity.ObjectEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ShortTag;
@@ -47,7 +47,7 @@ public class DroppedItem extends ObjectEntity {
         }
     }
 
-    private class ItemMetaData extends MetaData_1_13 {
+    private class ItemMetaData extends MetaData_1_19_3 {
         Slot item;
 
         @Override

--- a/src/main/java/game/data/entity/specific/Horse.java
+++ b/src/main/java/game/data/entity/specific/Horse.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 import game.data.container.Slot;
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import packets.UUID;
 import se.llbit.nbt.ByteTag;
@@ -43,7 +43,7 @@ public class Horse extends MobEntity {
         }
     }
 
-    private class HorseMetaData extends MetaData_1_13 {
+    private class HorseMetaData extends MetaData_1_19_3 {
 
         int variant = 0;
         UUID owner = null;

--- a/src/main/java/game/data/entity/specific/ItemFrame.java
+++ b/src/main/java/game/data/entity/specific/ItemFrame.java
@@ -5,7 +5,7 @@ import config.Option;
 import config.Version;
 import game.data.container.Slot;
 import game.data.entity.ObjectEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import se.llbit.nbt.ByteTag;
 import se.llbit.nbt.CompoundTag;
@@ -66,7 +66,7 @@ public class ItemFrame extends ObjectEntity {
         }
     }
 
-    private class ItemFrameMetaData extends MetaData_1_13 {
+    private class ItemFrameMetaData extends MetaData_1_19_3 {
         Slot item;
         int rotation;
 

--- a/src/main/java/game/data/entity/specific/Sheep.java
+++ b/src/main/java/game/data/entity/specific/Sheep.java
@@ -3,7 +3,7 @@ package game.data.entity.specific;
 import java.util.function.Consumer;
 
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import packets.DataTypeProvider;
 import se.llbit.nbt.ByteTag;
 import se.llbit.nbt.CompoundTag;
@@ -38,7 +38,7 @@ public class Sheep extends MobEntity {
         }
     }
 
-    private class SheepMetaData extends MetaData_1_13 {
+    private class SheepMetaData extends MetaData_1_19_3 {
 
         byte colorID = 0;
         boolean isSheared = false;

--- a/src/main/java/game/data/entity/specific/Villager.java
+++ b/src/main/java/game/data/entity/specific/Villager.java
@@ -6,7 +6,7 @@ import java.util.function.Consumer;
 
 import game.data.coordinates.CoordinateDim3D;
 import game.data.entity.MobEntity;
-import game.data.entity.metadata.MetaData_1_13;
+import game.data.entity.metadata.MetaData_1_19_3;
 import game.data.registries.RegistryManager;
 import game.data.villagers.VillagerTrade;
 import packets.DataTypeProvider;
@@ -99,7 +99,7 @@ public class Villager extends MobEntity {
         root.add("Xp", new IntTag(villagerExp));
     }
 
-    private class VillagerMetaData extends MetaData_1_13 {
+    private class VillagerMetaData extends MetaData_1_19_3 {
 
         boolean noAI;
         int headShakeTimer;

--- a/src/main/java/game/data/villagers/VillagerManager.java
+++ b/src/main/java/game/data/villagers/VillagerManager.java
@@ -1,5 +1,6 @@
 package game.data.villagers;
 
+import config.Config;
 import game.data.entity.EntityRegistry;
 import game.data.entity.IMovableEntity;
 import java.util.ArrayList;
@@ -46,10 +47,10 @@ public class VillagerManager {
         for (byte i = 0; i < numberOfTrades; i++) {
             Slot firstItem = provider.readSlot();
             Slot receivedItem = provider.readSlot();
-            boolean hasSecondItem = provider.readBoolean();
 
             Slot secondItem = null;
-            if (hasSecondItem) {
+            if (Config.versionReporter().isAtLeast1_19_3() || provider.readBoolean()) //is at least 1.19.3 or hasSecondItem = true
+            {
                 secondItem = provider.readSlot();
             }
 

--- a/src/main/resources/protocol-versions.json
+++ b/src/main/resources/protocol-versions.json
@@ -294,6 +294,7 @@
 				"0x23": "LightUpdate",
 				"0x24": "Login",
 				"0x25": "MapItemData",
+				"0x26": "TradeList",
 				"0x27": "MoveEntityPos",
 				"0x28": "MoveEntityPosRot",
 				"0x2c": "OpenScreen",


### PR DESCRIPTION
1.19.3 introduced VarLong as a potential data type in metadata, which changed the indexes of the types following it.

This PR also fixes some issues with villagers not being saved properly.