### PR TITLE
Replaced .exe builds with external launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ A Minecraft world downloader that works as a proxy server between the client and
 
 
 ### Downloads  <a href="https://github.com/mircokroon/minecraft-world-downloader/releases/latest"><img align="right" src="https://img.shields.io/github/downloads/mircokroon/minecraft-world-downloader/total.svg"></a>
-Latest Windows release (GUI): [world-downloader.exe](https://github.com/mircokroon/minecraft-world-downloader/releases/latest/download/world-downloader.exe)
+Windows launcher: [world-downloader-launcher.exe](https://github.com/mircokroon/minecraft-world-downloader-launcher/releases/latest/download/world-downloader-launcher.exe)
 
-Cross-platform jar (GUI & command-line): [world-downloader.jar](https://github.com/mircokroon/minecraft-world-downloader/releases/latest/download/world-downloader.jar)
+Latest cross-platform jar (command-line support): [world-downloader.jar](https://github.com/mircokroon/minecraft-world-downloader/releases/latest/download/world-downloader.jar)
 
 ### Basic usage
 [Download](https://github.com/mircokroon/minecraft-world-downloader/releases/latest/download/world-downloader.exe) the latest release and run it. Enter the server address in the address field and press start.

--- a/pom.xml
+++ b/pom.xml
@@ -98,54 +98,8 @@
                 <version>0.0.5</version>
             </plugin>
 
-            <plugin>
-                <groupId>com.akathist.maven.plugins.launch4j</groupId>
-                <artifactId>launch4j-maven-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>l4j-gui</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>launch4j</goal>
-                        </goals>
-                        <configuration>
-                            <headerType>gui</headerType>
-                            <outfile>target/world-downloader.exe</outfile>
-                            <jar>target/world-downloader.jar</jar>
-                            <errTitle>Error</errTitle>
-                            <classPath>
-                                <mainClass>Launcher</mainClass>
-                            </classPath>
-                            <icon>src/main/resources/ui/icon/icon.ico</icon>
-                            <jre>
-                                <!--
-                                    Include a few possible paths for the correct Java Runtime, including Minecraft's
-                                    own Java runtime.
-                                  -->
-                                <path>%JAVA_HOME%;%PATH%;C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64\bin;C:\Program Files (x86)\Minecraft Launcher\runtime\java-runtime-alpha\windows-x64\java-runtime-alpha\bin</path>
-                                <minVersion>${java.version}</minVersion>
-                                <initialHeapSize>256</initialHeapSize>
-                                <maxHeapSize>2048</maxHeapSize>
-                            </jre>
-                            <versionInfo>
-                                <fileVersion>${project.version}</fileVersion>
-                                <txtFileVersion>${project.version}</txtFileVersion>
-                                <fileDescription>Minecraft world downloader</fileDescription>
-                                <productVersion>${project.version}</productVersion>
-                                <copyright>!</copyright>
-                                <txtProductVersion>${project.version}</txtProductVersion>
-                                <productName>Minecraft world downloader</productName>
-                                <internalName>Minecraft world downloader</internalName>
-                                <originalFilename>world-downloader.exe</originalFilename>
-                            </versionInfo>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
.exe files are no longer part of the build process, replaced by a minimal external launcher project: https://github.com/mircokroon/minecraft-world-downloader-launcher

Closes #584
Closes #572 
Closes #568
Closes #558
Closes #536
Closes #500
Closes #482
Closes #481 
Closes #471

